### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "licenses": [
     {
       "type": "MIT"
-     
     }
   ],
   "main": "Gruntfile.js",
@@ -30,19 +29,19 @@
   "dependencies": {
     "jade": "~0.31.0",
     "grunt-lib-contrib": "~0.5.1",
-    "xml2tss":"http://github.com/Casear/xml2tss/tarball/master"
+    "xml2tss": "http://github.com/Casear/xml2tss/tarball/master"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-internal": "~0.4.2",
-    "grunt-contrib-coffee":"*",
-    "grunt-contrib-watch":"*",
+    "grunt-contrib-coffee": "*",
+    "grunt-contrib-watch": "*",
     "grunt": "~0.4.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
